### PR TITLE
[DM-27700] Return the username from the login route

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -495,12 +495,14 @@ For all routes listed below with a ``username`` path parameter, only administrat
     No data is sent with the request.
     The reply includes the CSRF value to use for all subsequent requests.
     See :ref:`API security <api-security>` for more information.
+    It also returns the authenticated username to assist in forming subsequent queries.
     Example:
 
     .. code-block:: json
 
        {
-         "csrf": "d56de7d8c6d90cc4a279666156c5923f"
+         "csrf": "d56de7d8c6d90cc4a279666156c5923f",
+         "username": "alice"
        }
 
 ``GET /auth/api/v1/users/{username}/tokens``


### PR DESCRIPTION
The UI needs to know the authenticated user in order to construct
URLs to obtain information about that user.  It could make a second
token-info call, but save a round-trip and return the necessary
information from the login route.